### PR TITLE
Add direction to ordering

### DIFF
--- a/src/main/java/com/dieselpoint/norm/Query.java
+++ b/src/main/java/com/dieselpoint/norm/Query.java
@@ -27,6 +27,7 @@ public class Query {
 	private String table;
 	private String where;
 	private String orderBy;
+	private String direction;
 
 	private Object[] args;
 
@@ -80,9 +81,21 @@ public class Query {
 
 	/**
 	 * Add an "orderBy" clause to a query.
+	 * @param string 
 	 */
 	public Query orderBy(String orderBy) {
 		this.orderBy = orderBy;
+		return this;
+	}
+	
+	/**
+	 * Add an "orderBy" clause with direction to a query.
+	 * @param orderBy 
+	 * @param direction 
+	 */
+	public Query orderBy(String orderBy, String direction) {
+		this.orderBy = orderBy;
+		this.direction = direction;
 		return this;
 	}
 
@@ -427,6 +440,10 @@ public class Query {
 
 	public String getTable() {
 		return table;
+	}
+	
+	public String getDirection() {
+		return direction;
 	}
 	
 }

--- a/src/main/java/com/dieselpoint/norm/sqlmakers/StandardSqlMaker.java
+++ b/src/main/java/com/dieselpoint/norm/sqlmakers/StandardSqlMaker.java
@@ -167,6 +167,7 @@ public class StandardSqlMaker implements SqlMaker {
 			table = pojoInfo.table;
 		}
 		String orderBy = query.getOrderBy();
+		String direction = query.getDirection();
 		
 		StringBuilder out = new StringBuilder();
 		out.append("select ");
@@ -180,6 +181,12 @@ public class StandardSqlMaker implements SqlMaker {
 		if (orderBy != null) {
 			out.append(" order by ");
 			out.append(orderBy);
+			
+			if (direction != null) {
+				out.append(" ");
+				out.append(direction);
+				out.append(" ");
+			}
 		}
 		return out.toString();
 	}

--- a/src/test/java/com/dieselpoint/norm/TestMySqlUpsert.java
+++ b/src/test/java/com/dieselpoint/norm/TestMySqlUpsert.java
@@ -1,6 +1,6 @@
 package com.dieselpoint.norm;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +14,7 @@ import com.dieselpoint.norm.sqlmakers.MySqlMaker;
 
 public class TestMySqlUpsert {
 	
+	@SuppressWarnings("rawtypes")
 	@Test
 	public void test() {
 	
@@ -35,11 +36,9 @@ public class TestMySqlUpsert {
 		db.upsert(row);
 		
 		List<HashMap> list = db.table("upserttest").results(HashMap.class);
+		assertEquals(1L, list.get(0).get("id"));
+		assertEquals("Fred", list.get(0).get("name"));
 		
-		String listStr = list.toString();
-		if (!listStr.equals("[{name=Fred, id=1}]")) {
-			fail();
-		}
 	}
 	
 	@Table(name="upserttest")

--- a/src/test/java/com/dieselpoint/norm/TestSelect.java
+++ b/src/test/java/com/dieselpoint/norm/TestSelect.java
@@ -1,6 +1,6 @@
 package com.dieselpoint.norm;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 public class TestSelect {
 	
+	@SuppressWarnings("unchecked")
 	@Test
 	public void test() {
 	
@@ -30,23 +31,16 @@ public class TestSelect {
 		
 		// primitive
 		Long myId = db.sql("select id from primitivetest").first(Long.class);
-		if (myId != 99) {
-			fail();
-		}
+		assertEquals(new Long(99), myId);
 		
 		// map
-		Map myMap = db.table("selecttest").first(LinkedHashMap.class);
-		String str = myMap.toString();
-		if (!str.equals("{id=99, name=bob}")) {
-			fail();
-		}
+		Map<String, Object> myMap = db.table("selecttest").first(LinkedHashMap.class);
+		assertEquals(99L, myMap.get("id"));
+		assertEquals("bob", myMap.get("name"));
 		
 		// pojo
 		Row myRow = db.first(Row.class);
-		String myRowStr = myRow.toString();
-		if (!myRowStr.equals("99bob")) {
-			fail();
-		}
+		assertEquals("99bob", myRow.toString());
 		
 	}
 	

--- a/src/test/java/com/dieselpoint/norm/TestSelect.java
+++ b/src/test/java/com/dieselpoint/norm/TestSelect.java
@@ -2,7 +2,9 @@ package com.dieselpoint.norm;
 
 import static org.junit.Assert.*;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.persistence.Column;
@@ -24,13 +26,11 @@ public class TestSelect {
 		
 		db.createTable(Row.class);
 		
-		Row row = new Row();
-		row.id = 99;
-		row.name = "bob";
-		db.insert(row);
+		Row firstRow = new Row(99, "bob");
+		db.insert(firstRow);
 		
 		// primitive
-		Long myId = db.sql("select id from primitivetest").first(Long.class);
+		Long myId = db.sql("select id from selecttest").first(Long.class);
 		assertEquals(new Long(99), myId);
 		
 		// map
@@ -42,6 +42,14 @@ public class TestSelect {
 		Row myRow = db.first(Row.class);
 		assertEquals("99bob", myRow.toString());
 		
+		Row secondRow = new Row(100, "ant");
+		db.insert(secondRow);
+		
+		List<HashMap> results = db.table("selecttest").orderBy("id", "desc").results(HashMap.class);
+		assertEquals(100L, results.get(0).get("id"));
+		assertEquals("ant", results.get(0).get("name"));
+		assertEquals(99L, results.get(1).get("id"));
+		assertEquals("bob", results.get(1).get("name"));
 	}
 	
 	@Table(name="selecttest")
@@ -49,6 +57,12 @@ public class TestSelect {
 		@Column(unique=true)
 		public long id;
 		public String name; 
+		public Row() {
+		}
+		public Row(long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
 		public String toString() {
 			return id + name;
 		}


### PR DESCRIPTION
Allow `orderBy` clause to be ordered by descending in addition to default ascending direction.

Improvement: maybe use enum instead String since direction is limited.
