### PR TITLE
Add max pool size property

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ Internally, Norm uses the [Hikari](http://brettwooldridge.github.io/HikariCP/) c
 
 If you don't want to use system properties, or your DataSource needs some custom startup parameters, just subclass the [Database](https://github.com/dieselpoint/norm/blob/master/src/main/java/com/dieselpoint/norm/Database.java) class and override the .getDataSource() method. You can supply any DataSource you like.
 
-In particular, you might want to override .getDataSource() to set the maximum number of connections that the connection pool opens. By default, it's set to 10. Tune it appropriately.
-
 ### Dependencies
 Norm needs javax.persistence, but that's just for annotations.
 

--- a/src/main/java/com/dieselpoint/norm/Database.java
+++ b/src/main/java/com/dieselpoint/norm/Database.java
@@ -26,6 +26,7 @@ public class Database {
 	private String databaseName = System.getProperty("norm.databaseName");
 	private String user = System.getProperty("norm.user");
 	private String password = System.getProperty("norm.password");
+	private int maxPoolSize = 10;
 
 	/**
 	 * Set the maker object for the particular flavor of sql.
@@ -44,7 +45,7 @@ public class Database {
 	 */
 	protected DataSource getDataSource() throws SQLException {
 		HikariConfig config = new HikariConfig();
-		config.setMaximumPoolSize(10);
+		config.setMaximumPoolSize(maxPoolSize);
 		
 		if (dataSourceClassName != null) {
 			config.setDataSourceClassName(dataSourceClassName);
@@ -246,5 +247,13 @@ public class Database {
 	public void setPassword(String password) {
 		this.password = password;
 	}
-	
+
+	public int getMaxPoolSize() {
+		return maxPoolSize;
+	}
+
+	public void setMaxPoolSize(int maxPoolSize) {
+		this.maxPoolSize = maxPoolSize;
+	}
+
 }


### PR DESCRIPTION
The README states that you can override getDataSource() to tune the max pool size property, however this simple addition would remove the need to override the large method. 