### PR TITLE
Added latency checking. See LatencyChecking.md

### DIFF
--- a/LatencyChecking.md
+++ b/LatencyChecking.md
@@ -1,0 +1,60 @@
+# Norm Latency Checking
+
+Norm is awesome! Having spent years running heavyweight ORM solutions, norm is the perfect combination of a lighweight library that makes life super-easy, while still letting me get my hands really dirty.
+
+The one feature that I feel strongly belongs to the 90% (see [README.md](README.md)) is latency checking. I've learned the hard way that actively managing the database is crucial and that (no matter how well intentioned your development team) performance will degrade over time. A few milliseconds a month, a couple of dodgy queries, and suddently your site is performing like a tortoise racing through treacle because the database can't clear the backlog before the next tranche of queries turns up.
+
+The best solution I've found is to be super-opinionated about what constitutes acceptable database latency from day one of development; to use tooling that immediately reports (and ideally breaks your tests) when latency breaches reasonable boundaries in your dev/test environments; and carry that tooling into production to keep an eye on degredation over time.
+
+So I've extended norm to add latency checking functionality. The code should be transparent, backward-compatible and introduces no additional dependencies. Now you can do:
+
+```java
+Database db = new Database();
+...
+db.setMaxLatency(30); // alert every time any call to the database takes >30 milliseconds
+
+// report latency violations using an slf4j logger
+db.addLatencyAlerter( new Slf4jLatencyAlerter() );
+
+// also throw an exception when latency violations occur (only sensible in development/test!)
+db.addLatencyAlerter( new ExceptionLatencyAlerter() ); 
+
+// raise an alert if latency on these queries are >20ms
+var people = db.where("lastname=?", "Sixpack").maxLatency(20).results(Person.class);
+db.sql("select count(*) from people").maxLatency(20).first(Long.class);
+
+// transactions work in exactly the same way
+Transaction trans = db.startTransaction().maxLatency(30);
+try {
+	...
+	trans.commit();
+} catch (Throwable t) {
+	trans.rollback();
+} 
+```
+
+Should any of the queries / transaction commits exceed the max latency (whether global or for an individual transaction), then a message is logged showing the actual and expected time, along with the offending line of code.
+
+One fun side-effect of this functionality is that setting maxLatency to 0ms, causes all SQL Statements to be logged, along with their elapsed execution time. By default maxLatency is set to -1: an ugly magic number but one that skips all the latency code.
+
+It's also worth noting that setting the latency on a Query/Transaction supercedes the global latency setting for the Database. This is deliberate so you can (for example) set the global latency to 30ms and latency for a super-complex transaction to 50ms.
+
+In keeping with existing norm capabilities, you can also set the global Database latency using environment variable `norm.maxLatency`
+
+As you can see from the code above, you add `LatencyAlerters` to the Database instance. These are called in the order which they were added. There are four simple LatencyAlerters included, and it should be trivial to add more.
+
+As an example of a LatencyAlerter, at [Divrsity](https://divrsity.team) we use HoneyBadger.io to raise an alert any time the database latency threshold is exceeded. Of course, you really don't want to further compromise customer experience due to the wait time for reporting (and you don't want a million alerts) so you'll want to implement some kind of backoff+jitter algorithm. A basic implementation is included: just subclass BackoffLatencyAlerter and implement the alertLatencyFailureAfterBackoffAndJitter() method. Then you can do:
+
+```java
+var hbAlerter = HoneyBadgerAlerter( Duration.ofMillis( 500 ), Duration.ofMinutes( 10 ) );
+db.addLatencyAlerter( hbAlerter );
+```
+
+to report at most every 0.5 seconds, and at least once every 10 minutes.
+
+N.B. Checking latency on Transaction rollback would be trivial, but I'd need to be convinced that it makes sense. If you're routinely rolling back transctions then you probably need to look at your logic (or just copy the missing two lines of code from the commit method to the rollback method).
+
+The code has been running in production on for about a month or so, with a maxLatency of 25ms. We use AWS Aurora Postgres (which is properly awesome) and, so far, have seen just one (temporary) latency breach.
+
+Mark(at)divrsity(dot)team
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Read a blog post on this project.](https://blog.dieselpoint.com/a-minimalist-good-enough-approach-to-object-relational-mapping-64df9798b276)
 
-Norm is a simple way to access a JDBC database, usually in one line of code. It purges your code of the complex mess that is [Hibernate](http://www.hibernate.org), [JPA](http://en.wikipedia.org/wiki/Java_Persistence_API), and [ORM](http://en.wikipedia.org/wiki/Object-relational_mapping). 
+Norm is a simple way to access a JDBC database, usually in one line of code. It purges your code of the complex mess that is [Hibernate](http://www.hibernate.org), [JPA](http://en.wikipedia.org/wiki/Java_Persistence_API), and [ORM](http://en.wikipedia.org/wiki/Object-relational_mapping).
 
 [Lots of people think that complex ORMs are a bad idea.](http://stackoverflow.com/questions/398134/what-are-the-advantages-of-using-an-orm/398182)
 
@@ -20,7 +20,7 @@ List<Person> people = db.where("name=?", "Bob").results(Person.class);
 
 ### Overview
 
-Norm is an extremely lightweight layer over JDBC. It gets rid of large amounts of boilerplate JDBC code. It steals some ideas from [ActiveJDBC](hhttp://javalite.io/), which is a very nice system, but requires some very ugly instrumentation / byte code rewriting. 
+Norm is an extremely lightweight layer over JDBC. It gets rid of large amounts of boilerplate JDBC code. It steals some ideas from [ActiveJDBC](hhttp://javalite.io/), which is a very nice system, but requires some very ugly instrumentation / byte code rewriting.
 
 ### Why?
 
@@ -78,7 +78,7 @@ When you need more than this, just use straight SQL. This is the best way to do 
 
 ```Java
 List<MyPojo> list1 = db.sql(
-    "select lastname, sum(amount) from account, transaction " + 
+    "select lastname, sum(amount) from account, transaction " +
     "where account.accountId = transaction.accountId " +
 	"and date > ?", "2000-01-01")
 	.results(MyPojo.class);
@@ -104,7 +104,7 @@ Note that you must specify full sql, or at a minimum a table name, because the s
 
 ### Primitives
 
-A single column result set can come back in the form of a list of primitives, or even as a single primitive. 
+A single column result set can come back in the form of a list of primitives, or even as a single primitive.
 
 ```Java
 Long count = db.sql("select count(*) from people").first(Long.class);
@@ -165,10 +165,30 @@ try {
 	trans.commit();
 } catch (Throwable t) {
 	trans.rollback();
-} 
+}
 
 ```
 Transaction is a pretty simple class, so if it doesn't do what you need,  just subclass it and make it behave differently.
+
+### Latency Checking
+
+As data volumes increase and functionality enhancements are made, the calls to your database have a nasty habit of slowing down. For the whole database, or for individual Queries and Transactions, you can specify a max acceptable latency. Database calls exceeding that SLA will be reported via a pluggable LatencyAlerter.
+
+```Java
+ // alert with an slf4j log message any call to the database takes >30 milliseconds
+db.setMaxLatency(30);
+db.addLatencyAlerter( new Slf4jLatencyAlerter() );
+
+// raise an alert if latency on these queries exceeds >20ms
+var people = db.where("lastname=?", "Sixpack").maxLatency(20).results(Person.class);
+db.sql("select count(*) from people").maxLatency(20).first(Long.class);
+
+// latency checking also works with Transaction commits
+Transaction trans = db.startTransaction().maxLatency(30);
+
+```
+More information can be found here: [LatencyChecking.md](LatencyChecking.md)
+
 
 ### Custom Serialization
 
@@ -203,7 +223,7 @@ Some database-specific notes:
 
 MySQL: Should work out of the box.
 
-Postgres: Inexplicably, Postgres converts all column names to lowercase when you create a table, and 
+Postgres: Inexplicably, Postgres converts all column names to lowercase when you create a table, and
 forces you to use double quotes around column names if you want mixed or upper case. The workaround
 is to add an @Column(name="somelowercasename") annotation to the fields in your pojo.
 
@@ -232,7 +252,7 @@ db.setUser("root");
 db.setPassword("rootpassword");
 ```
 
-or 
+or
 
 ```Java
 System.setProperty("norm.jdbcUrl", "jdbc:mysql://localhost:3306/mydb?useSSL=false");
@@ -240,14 +260,14 @@ System.setProperty("norm.user", "root");
 System.setProperty("norm.password", "rootpassword");
 ```
 
-Internally, Norm uses the [Hikari](http://brettwooldridge.github.io/HikariCP/) connection pool. Hikari allows you to use the jdbcUrl method or [DataSource class names](https://github.com/brettwooldridge/HikariCP#popular-datasource-class-names). Your database is bound to be on the list. 
+Internally, Norm uses the [Hikari](http://brettwooldridge.github.io/HikariCP/) connection pool. Hikari allows you to use the jdbcUrl method or [DataSource class names](https://github.com/brettwooldridge/HikariCP#popular-datasource-class-names). Your database is bound to be on the list.
 
 If you don't want to use system properties, or your DataSource needs some custom startup parameters, just subclass the [Database](https://github.com/dieselpoint/norm/blob/master/src/main/java/com/dieselpoint/norm/Database.java) class and override the .getDataSource() method. You can supply any DataSource you like.
 
 ### Dependencies
 Norm needs javax.persistence, but that's just for annotations.
 
-It also has a dependency on HikariCP for connection pooling, but that's entirely optional. If you don't want it, add an `<exclude>`  to the Norm dependency in your project's pom. Then subclass Database and override the getDataSource() method. 
+It also has a dependency on HikariCP for connection pooling, but that's entirely optional. If you don't want it, add an `<exclude>`  to the Norm dependency in your project's pom. Then subclass Database and override the getDataSource() method.
 
 Finally, you'll need to include your JDBC driver as a dependency. Here's a sample for MySQL:
 
@@ -261,9 +281,4 @@ Finally, you'll need to include your JDBC driver as a dependency. Here's a sampl
 
 ****
 
-That's about it. Post any bugs or feature requests to the issue tracker. 
-
-
-
-
-
+That's about it. Post any bugs or feature requests to the issue tracker.

--- a/src/main/java/com/dieselpoint/norm/latency/BackoffLatencyAlerter.java
+++ b/src/main/java/com/dieselpoint/norm/latency/BackoffLatencyAlerter.java
@@ -1,0 +1,83 @@
+package com.dieselpoint.norm.latency;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Random;
+
+/**
+ * One of the dangers when reporting latency issues to external services, is that the reporting itself a) takes a
+ * significant amount of time and may create Customer Experience issues, and b) you end up with millions of latency
+ * alerts when a database goes bad. <p></p>This class implements a basic "exponential backoff with jitter" algorithm. Subclasses
+ * can simply implement {@link BackoffLatencyAlerter#alertLatencyFailureAfterBackoffAndJitter(DbLatencyWarning, long)}
+ * to take advantage of the exponential backoff facility.
+ * <p>{@code var cwAlerter = CloudWatchAlerter( Duration.ofMillis( 500 ), Duration.ofMinutes( 10 ) ); } will initially
+ * alert at 500ms intervals, then 1000ms (1 second), 2 seconds, 4 seconds .... 10 minutes.
+ * <p>For more information, refer to
+ * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">Exponential Backoff And Jitter</a>
+ * by Amazon Web Services
+ * <p>When implementing your alerter, remember to swallow errors. You don't want your platform slowing down/failing
+ * because the monitoring service is failing. See the
+ * {@link BackoffLatencyAlerter#alertLatencyFailureAfterBackoffAndJitter(DbLatencyWarning, long)} documentation for
+ * further steps to ensure that monitoring doesn't accidentally become a significant overhead.
+ */
+@SuppressWarnings( "unused" )
+public abstract class BackoffLatencyAlerter implements LatencyAlerter {
+    private static final Logger logger = LoggerFactory.getLogger( BackoffLatencyAlerter.class );
+
+    private final long minimumReportingLatencyMillis, maximumReportingIntervalMillis;
+    private long nextReportTime;
+    private double backoffs;
+    private long alertsSwallowedWhileWaiting = 0;
+    private final Random random = new Random();
+
+    public BackoffLatencyAlerter( Duration minimumReportingInterval, Duration maximumReportingInterval ) {
+        this.minimumReportingLatencyMillis = minimumReportingInterval.toMillis();
+        this.maximumReportingIntervalMillis = maximumReportingInterval.toMillis();
+        this.backoffs = 1;
+        this.nextReportTime = System.currentTimeMillis();
+    }
+
+    private long calculateWaitTime() {
+        backoffs += (alertsSwallowedWhileWaiting > 0) ? 1 : -0.25; // come back down much more slowly than we went up
+        backoffs = backoffs < 1 ? 1 : backoffs;
+
+        // timeToWait = (base * 2^n) +/- (jitter)
+        long jitter = (minimumReportingLatencyMillis/2) - (random.nextLong() % minimumReportingLatencyMillis);
+        long timeToWait = (minimumReportingLatencyMillis * (long)Math.pow(2, backoffs) ) + jitter;
+        if (timeToWait > maximumReportingIntervalMillis) {
+            // timeToWait = maximumReportingIntervalMillis; - NO, we still want the jitter included
+            --backoffs;
+        }
+        return timeToWait;
+    }
+
+    @Override
+    public synchronized void alertLatencyFailure( DbLatencyWarning warning ) {
+        if (warning.maxAcceptableLatency != 0) {
+            long myTime = System.currentTimeMillis();
+            if (nextReportTime <= myTime) {
+                if (alertLatencyFailureAfterBackoffAndJitter( warning, alertsSwallowedWhileWaiting ) == false)
+                    ++alertsSwallowedWhileWaiting;
+                nextReportTime = myTime + calculateWaitTime();
+                alertsSwallowedWhileWaiting = 0;
+            }
+            else {
+                logger.info( "Swallowed latency failure:" + warning );
+                ++alertsSwallowedWhileWaiting;
+            }
+        }
+    }
+
+    /**
+     * @param warning the latency warning
+     * @param numberOfAlertsSwallowed the number of alerts that were swallowed during the exponential backoff period. This
+     *                                might (or might not) be interesting to report alongside the current issue. It'll
+     *                                definitely give you a sense of how bad things have gone!
+     * @return true if notifying the remote service was successful, false otherwise. If false, then we'll automatically
+     *          backoff calls to reporting in the same way as latency failures, to avoid a slowdown / issue on
+     *          monitoring impacting the actual customer experience
+     */
+    public abstract boolean alertLatencyFailureAfterBackoffAndJitter( DbLatencyWarning warning, long numberOfAlertsSwallowed );
+}

--- a/src/main/java/com/dieselpoint/norm/latency/DbLatencyWarning.java
+++ b/src/main/java/com/dieselpoint/norm/latency/DbLatencyWarning.java
@@ -1,0 +1,56 @@
+package com.dieselpoint.norm.latency;
+
+import com.dieselpoint.norm.Transaction;
+
+import java.util.Arrays;
+
+/**
+ * An exception-like class, that makes it easy to pass the messages, and stack trace associated
+ * with a {@link com.dieselpoint.norm.Query} or {@link Transaction#commit()} database call that has
+ * exceeded its latency threshold. LatencyAlerters can make a decision how to alert
+ * the system administrators to the warning
+ */
+public class DbLatencyWarning {
+    public final long maxAcceptableLatency;
+    public final long actualLatency;
+    public final String cause;
+    public final String offendingStatement;
+
+    protected DbLatencyWarning( long maxAcceptableLatency, long actualLatency, String cause ) {
+        this.maxAcceptableLatency = maxAcceptableLatency;
+        this.actualLatency = actualLatency;
+        this.cause = cause;
+        this.offendingStatement = getOffendingStatement();
+    }
+
+    public DbLatencyWarning(long maxAcceptableLatency, long actualLatency, String theNaughtySql, Object[] theNaughtyArgs ) {
+        this( maxAcceptableLatency, actualLatency,
+                        "SQL:" + theNaughtySql + ", SQL_Args:" + Arrays.deepToString(theNaughtyArgs) );
+    }
+
+    public DbLatencyWarning(long maxAcceptableLatency, long actualLatency, Transaction theNaughtyTransaction ) {
+        this( maxAcceptableLatency, actualLatency, "Transaction commit exceeded threshold:" );
+    }
+
+    /**
+     * @return the most recent call on the stack before any call to classes in the {@code com.dieselpoint.norm} package.
+     * This ought to pinpoint the call that exceeded the latency threshold. Returns {@code "[Unknown]"}, when it can't
+     * figure out the caller, i.e. will never return null
+     */
+    private String getOffendingStatement() {
+        StackTraceElement[] elements = Thread.currentThread().getStackTrace();
+        for (int i=2; i<elements.length; i++) {
+            StackTraceElement e = elements[i];
+            // ignore everything in the com.dieselpoint.norm package
+            if (e.getClassName().startsWith( "com.dieselpoint.norm.") == false)
+                return e.toString();
+        }
+        return "[Unknown]";
+    }
+
+    public String toString() {
+        if (maxAcceptableLatency == 0)
+            return "Database Latency was: " + actualLatency + "ms, at " + offendingStatement + ". " + cause;
+        return "Database Latency was: " + actualLatency + "ms, at " + offendingStatement + ", versus max acceptable: " + maxAcceptableLatency + "ms. Caused by " + cause;
+    }
+}

--- a/src/main/java/com/dieselpoint/norm/latency/ExceptionLatencyAlerter.java
+++ b/src/main/java/com/dieselpoint/norm/latency/ExceptionLatencyAlerter.java
@@ -1,0 +1,19 @@
+package com.dieselpoint.norm.latency;
+
+import com.dieselpoint.norm.DbException;
+
+/**
+ * For use in development/testing environment, throws an Exception when the latency has exceeded the threshold.
+ * For early warning of latency issues, it's good practise to prevent tests from passing when latency exceeds the threshold
+ */
+public class ExceptionLatencyAlerter implements LatencyAlerter {
+
+    public ExceptionLatencyAlerter() {
+    }
+
+    @Override
+    public void alertLatencyFailure( DbLatencyWarning warning ) {
+        if (warning.maxAcceptableLatency > 0)
+            throw new DbException( warning.toString() );
+    }
+}

--- a/src/main/java/com/dieselpoint/norm/latency/LatencyAlerter.java
+++ b/src/main/java/com/dieselpoint/norm/latency/LatencyAlerter.java
@@ -1,0 +1,11 @@
+package com.dieselpoint.norm.latency;
+
+/**
+ * Interface used to alert administrators to latency issues. Multiple LatencyAlerters can be added to a Database, using
+ * the addLatencyAlerter. They will be called in order that they are added.<br>
+ * Implementations are provided that log with Slf4j, that log to standard out and that throw an exception, but
+ * it should be trivial to forward the latency alert to e.g. AWS Cloudwatch, PagerDuty, or honeybadger.io
+ */
+public interface LatencyAlerter {
+    public void alertLatencyFailure( DbLatencyWarning warning );
+}

--- a/src/main/java/com/dieselpoint/norm/latency/LatencyTimer.java
+++ b/src/main/java/com/dieselpoint/norm/latency/LatencyTimer.java
@@ -1,0 +1,59 @@
+package com.dieselpoint.norm.latency;
+
+import com.dieselpoint.norm.Database;
+import com.dieselpoint.norm.Query;
+import com.dieselpoint.norm.Transaction;
+
+/**
+ * Utility class that abstracts the starting / stopping of timers and checking whether sql duration was within threshold
+ */
+public class LatencyTimer {
+    public final long startMillis;
+    public long duration;
+    public final long maxAcceptableLatency;
+    public final Database db;
+
+    public LatencyTimer( Query query ) {
+        this.db = query.getDatabase();
+        startMillis = System.currentTimeMillis();
+        maxAcceptableLatency = query.getMaxLatencyMillis();
+    }
+
+    public LatencyTimer( Transaction transaction ) {
+        this.db = transaction.getDatabase();
+        startMillis = System.currentTimeMillis();
+        maxAcceptableLatency = transaction.getMaxLatencyMillis();
+    }
+
+    /**
+     * @return true if latency was within acceptable bounds, or maxAcceptableLatency is negative
+     */
+    private boolean stop() {
+        if (maxAcceptableLatency < 0)
+            return true;
+        duration = System.currentTimeMillis() - startMillis;
+        if (maxAcceptableLatency == 0)
+            return false;
+        return duration <= maxAcceptableLatency;
+    }
+
+    public boolean stop( String sql, Object[] args ) {
+        if (stop() == false) {
+            if (db != null) {
+                db.alertLatency( new DbLatencyWarning( maxAcceptableLatency, duration, sql, args ) );
+            }
+        }
+        return false;
+    }
+
+    public boolean stop( Transaction aTransaction ) {
+        if (stop() == false) {
+            if (db != null) {
+                db.alertLatency( new DbLatencyWarning( maxAcceptableLatency, duration, aTransaction ) );
+            }
+        }
+        return false;
+    }
+
+
+}

--- a/src/main/java/com/dieselpoint/norm/latency/Slf4jLatencyAlerter.java
+++ b/src/main/java/com/dieselpoint/norm/latency/Slf4jLatencyAlerter.java
@@ -1,0 +1,25 @@
+package com.dieselpoint.norm.latency;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Slf4jLatencyAlerter implements LatencyAlerter {
+    private static final Logger logger = LoggerFactory.getLogger( Slf4jLatencyAlerter.class );
+    private final Logger instanceLogger;
+
+    public Slf4jLatencyAlerter() {
+        this( logger );
+    }
+
+    public Slf4jLatencyAlerter( Logger theLoggerToUse ) {
+        instanceLogger = theLoggerToUse;
+    }
+
+    @Override
+    public void alertLatencyFailure( DbLatencyWarning warning ) {
+        if (warning.maxAcceptableLatency == 0)
+            instanceLogger.info( warning.toString() );
+        else
+            instanceLogger.warn( warning.toString() );
+    }
+}

--- a/src/main/java/com/dieselpoint/norm/latency/StdoutLatencyAlerter.java
+++ b/src/main/java/com/dieselpoint/norm/latency/StdoutLatencyAlerter.java
@@ -1,0 +1,12 @@
+package com.dieselpoint.norm.latency;
+
+public class StdoutLatencyAlerter implements LatencyAlerter {
+
+    public StdoutLatencyAlerter() {
+    }
+
+    @Override
+    public void alertLatencyFailure( DbLatencyWarning warning ) {
+        System.out.println( warning.toString() );
+    }
+}


### PR DESCRIPTION
Keeping on top of Database latency is critical for production applications. The (backwards compatible code, with no additional dependencies), enables you to set a max latency for all database operations, and/or for individual queries/transactions. Pluggable LatencyReporters allow you to log latency issues, or report them to an external service such as CloudWatch or HoneyBadger.io.