### PR TITLE
Fix StandardSqlMaker and MySqlMaker ignore table argument in Query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.dieselpoint</groupId>
 	<artifactId>norm</artifactId>
 	<name>Norm</name>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<packaging>jar</packaging>
 
 	<description>An extremely lightweight data access layer over JDBC</description>
@@ -62,7 +62,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<release>11</release>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -138,7 +139,7 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>3.4.5</version>
+			<version>5.0.1</version>
 		</dependency>
 
 		<dependency>
@@ -151,21 +152,21 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.3.3</version>
+			<version>42.3.6</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.1.210</version>
+			<version>2.1.212</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.32.3.2</version>
+			<version>3.36.0.3</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -186,7 +187,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/com/dieselpoint/norm/Database.java
+++ b/src/main/java/com/dieselpoint/norm/Database.java
@@ -1,20 +1,19 @@
 package com.dieselpoint.norm;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.sql.DataSource;
-
 import com.dieselpoint.norm.latency.DbLatencyWarning;
 import com.dieselpoint.norm.latency.LatencyAlerter;
 import com.dieselpoint.norm.sqlmakers.SqlMaker;
 import com.dieselpoint.norm.sqlmakers.StandardSqlMaker;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Provides methods to access a database.
@@ -105,7 +104,7 @@ public class Database {
 	/**
 	 * Create a query using straight SQL. Overrides any other methods like .where(),
 	 * .orderBy(), etc.
-	 * 
+	 *
 	 * @param sql  The SQL string to use, may include ? parameters.
 	 * @param args The parameter values to use in the query.
 	 */
@@ -115,7 +114,7 @@ public class Database {
 
 	/**
 	 * Create a query with the given where clause.
-	 * 
+	 *
 	 * @param where Example: "name=?"
 	 * @param args  The parameter values to use in the where, example: "Bob"
 	 */
@@ -228,7 +227,7 @@ public class Database {
 	 * command that should be part of the transaction using the .transaction()
 	 * method. Then call transaction.commit() or .rollback() to complete the
 	 * process. No need to close the transaction.
-	 * 
+	 *
 	 * @return a transaction object
 	 */
 	public Transaction startTransaction() {
@@ -288,7 +287,7 @@ public class Database {
 
 	/**
 	 * @param millis the maximum latency that all {@link Query} or {@link Transaction#commit()} calls should tolerate.
-	 * By default millis is set to {@code -1 } which turns off all latency alerting. Note that setting maxLatency to {@code 0} is
+	 * By default, millis is set to {@code -1 } which turns off all latency alerting. Note that setting maxLatency to {@code 0} is
 	 * an easy way to log all SQL Statements. This value can also be set using environment variable {@code norm.maxLatency }
 	 */
 	public void setMaxLatency( long millis ) {

--- a/src/main/java/com/dieselpoint/norm/Query.java
+++ b/src/main/java/com/dieselpoint/norm/Query.java
@@ -1,19 +1,14 @@
 package com.dieselpoint.norm;
 
-import java.lang.reflect.InvocationTargetException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.dieselpoint.norm.latency.LatencyTimer;
 import com.dieselpoint.norm.sqlmakers.PojoInfo;
 import com.dieselpoint.norm.sqlmakers.SqlMaker;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Holds all of the information in a query. Create a query using
@@ -37,8 +32,8 @@ public class Query {
 
 	private ResultSetMetaData meta;
 
-	private Database db;
-	private SqlMaker sqlMaker;
+	private final Database db;
+	private final SqlMaker sqlMaker;
 	private long maxLatency;
 
 	private Transaction transaction;
@@ -52,7 +47,7 @@ public class Query {
 	/**
 	 * Add a where clause and some parameters to a query. Has no effect if the
 	 * .sql() method is used.
-	 * 
+	 *
 	 * @param where Example: "name=?"
 	 * @param args  The parameter values to use in the where, example: "Bob"
 	 */
@@ -65,7 +60,7 @@ public class Query {
 	/**
 	 * Create a query using straight SQL. Overrides any other methods like .where(),
 	 * .orderBy(), etc.
-	 * 
+	 *
 	 * @param sql  The SQL string to use, may include ? parameters.
 	 * @param args The parameter values to use in the query.
 	 */
@@ -78,7 +73,7 @@ public class Query {
 	/**
 	 * Create a query using straight SQL. Overrides any other methods like .where(),
 	 * .orderBy(), etc.
-	 * 
+	 *
 	 * @param sql  The SQL string to use, may include ? parameters.
 	 * @param args The parameter values to use in the query.
 	 */
@@ -420,29 +415,29 @@ public class Query {
 						pojoInfo.putValue(generatedKeyReceiver, generatedKeyName, value);
 
 						/*-
-						
-						
+
+
 						Property prop = pojoInfo.getProperty(generatedKeyName);
 						if (prop == null) {
 							throw new DbException("Generated key name not found: " + generatedKeyName);
 						}
-						
+
 						/*
 						 * getObject() below doesn't handle primitives correctly. Must convert to object
 						 * equivalent.
 						 * /
-						
+
 						Class<?> type = Util.wrap(prop.dataType);
-						
+
 						Object colValue = sqlMaker.convertValue(rs.getObject(i), meta.getColumnTypeName(i));
-						
+
 						Object newKey;
 						if (colCount == 1) {
 							newKey = rs.getObject(1, type);
 						} else {
 							newKey = rs.getObject(prop.name, type);
 						}
-						
+
 						pojoInfo.putValue(generatedKeyReceiver, prop.name, newKey);
 						*/
 					}
@@ -456,7 +451,7 @@ public class Query {
 			if (rs != null) {
 				try {
 					rs.close();
-				} catch (SQLException e) {
+				} catch (SQLException ignored) {
 				}
 			}
 		}
@@ -483,19 +478,19 @@ public class Query {
 
 	/**
 	 * Temporary hack. Avoid.
-	 * 
+	 *
 	 * @deprecated
 	 * @param generatedKeyName
 	 * @return / public Query generatedKeyName(String generatedKeyName) {
 	 *         this.generatedKeyName = generatedKeyName; return this; }
-	 * 
+	 *
 	 *         public long getGeneratedKeyValue() { return generatedKeyValue; }
 	 */
 
 	/**
 	 * This is a temporary hack to deal with inserting Maps using sql. May go away.
 	 * Marking this deprecated right from the start.
-	 * 
+	 *
 	 * @deprecated
 	 * @return / public long getGeneratedKey(String colName) { if (generatedKeys !=
 	 *         null) { try { return generatedKeys.getLong(colName); } catch

--- a/src/main/java/com/dieselpoint/norm/converter/IntArrayToListConverter.java
+++ b/src/main/java/com/dieselpoint/norm/converter/IntArrayToListConverter.java
@@ -1,14 +1,14 @@
 package com.dieselpoint.norm.converter;
 
-import java.sql.Array;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import com.dieselpoint.norm.DbException;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
-
-import com.dieselpoint.norm.DbException;
+import java.sql.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Converter
 public class IntArrayToListConverter implements AttributeConverter<List<Integer>, java.sql.Array> {
@@ -25,13 +25,9 @@ public class IntArrayToListConverter implements AttributeConverter<List<Integer>
 			if (dbData.getBaseType() != java.sql.Types.INTEGER) {
 				throw new DbException("Database is not returning an integer array");
 			}
-			
+
 			Integer [] arr = (Integer[]) dbData.getArray();
-			List<Integer> out = new ArrayList<>();
-			for (Integer i: arr) {
-				out.add(i);
-			}
-			return out;
+			return new ArrayList<>(Arrays.asList(arr));
 
 		} catch (SQLException e) {
 			throw new DbException(e);

--- a/src/main/java/com/dieselpoint/norm/converter/SimpleArray.java
+++ b/src/main/java/com/dieselpoint/norm/converter/SimpleArray.java
@@ -5,10 +5,10 @@ import java.sql.SQLException;
 import java.util.Map;
 
 public class SimpleArray implements java.sql.Array {
-	
-	private int baseType;
-	private Object [] arr;
-	
+
+	private final int baseType;
+	private final Object [] arr;
+
 	public SimpleArray(int baseType, Object [] arr) {
 		this.baseType = baseType;
 		this.arr = arr;

--- a/src/main/java/com/dieselpoint/norm/latency/BackoffLatencyAlerter.java
+++ b/src/main/java/com/dieselpoint/norm/latency/BackoffLatencyAlerter.java
@@ -58,7 +58,7 @@ public abstract class BackoffLatencyAlerter implements LatencyAlerter {
         if (warning.maxAcceptableLatency != 0) {
             long myTime = System.currentTimeMillis();
             if (nextReportTime <= myTime) {
-                if (alertLatencyFailureAfterBackoffAndJitter( warning, alertsSwallowedWhileWaiting ) == false)
+                if (!alertLatencyFailureAfterBackoffAndJitter(warning, alertsSwallowedWhileWaiting))
                     ++alertsSwallowedWhileWaiting;
                 nextReportTime = myTime + calculateWaitTime();
                 alertsSwallowedWhileWaiting = 0;

--- a/src/main/java/com/dieselpoint/norm/latency/DbLatencyWarning.java
+++ b/src/main/java/com/dieselpoint/norm/latency/DbLatencyWarning.java
@@ -42,7 +42,7 @@ public class DbLatencyWarning {
         for (int i=2; i<elements.length; i++) {
             StackTraceElement e = elements[i];
             // ignore everything in the com.dieselpoint.norm package
-            if (e.getClassName().startsWith( "com.dieselpoint.norm.") == false)
+            if (!e.getClassName().startsWith("com.dieselpoint.norm."))
                 return e.toString();
         }
         return "[Unknown]";

--- a/src/main/java/com/dieselpoint/norm/latency/LatencyTimer.java
+++ b/src/main/java/com/dieselpoint/norm/latency/LatencyTimer.java
@@ -38,7 +38,7 @@ public class LatencyTimer {
     }
 
     public boolean stop( String sql, Object[] args ) {
-        if (stop() == false) {
+        if (!stop()) {
             if (db != null) {
                 db.alertLatency( new DbLatencyWarning( maxAcceptableLatency, duration, sql, args ) );
             }
@@ -47,7 +47,7 @@ public class LatencyTimer {
     }
 
     public boolean stop( Transaction aTransaction ) {
-        if (stop() == false) {
+        if (!stop()) {
             if (db != null) {
                 db.alertLatency( new DbLatencyWarning( maxAcceptableLatency, duration, aTransaction ) );
             }

--- a/src/main/java/com/dieselpoint/norm/sqlmakers/MySqlMaker.java
+++ b/src/main/java/com/dieselpoint/norm/sqlmakers/MySqlMaker.java
@@ -2,43 +2,45 @@ package com.dieselpoint.norm.sqlmakers;
 
 import com.dieselpoint.norm.Query;
 
+import java.util.Objects;
+
 
 public class MySqlMaker extends StandardSqlMaker {
 
 	@Override
 	public String getUpsertSql(Query query, Object row) {
 		StandardPojoInfo pojoInfo = getPojoInfo(row.getClass());
-		return pojoInfo.upsertSql;
+		return String.format(pojoInfo.upsertSql, Objects.requireNonNullElse(query.getTable(), pojoInfo.table));
 	}
 
 	@Override
 	public Object[] getUpsertArgs(Query query, Object row) {
-		
+
 		// same args as insert, but we need to duplicate the values
 		Object [] args = super.getInsertArgs(query, row);
-		
+
 		int count = args.length;
-		
+
 		Object [] upsertArgs = new Object[count * 2];
 		System.arraycopy(args, 0, upsertArgs, 0, count);
 		System.arraycopy(args, 0, upsertArgs, count, count);
-		
+
 		return upsertArgs;
 	}
-	
+
 
 	@Override
 	public void makeUpsertSql(StandardPojoInfo pojoInfo) {
 
 		// INSERT INTO table (a,b,c) VALUES (1,2,3) ON DUPLICATE KEY UPDATE c=c+1;
-		
+
 		// mostly the same as the makeInsertSql code
 		// it uses the same column names and argcount
 
 		StringBuilder buf = new StringBuilder();
 		buf.append(pojoInfo.insertSql);
 		buf.append(" on duplicate key update ");
-		
+
 		boolean first = true;
 		for (String colName: pojoInfo.insertColumnNames) {
 			if (first) {
@@ -49,7 +51,7 @@ public class MySqlMaker extends StandardSqlMaker {
 			buf.append(colName);
 			buf.append("=?");
 		}
-		
+
 		pojoInfo.upsertSql = buf.toString();
 	}
 

--- a/src/main/java/com/dieselpoint/norm/sqlmakers/StandardPojoInfo.java
+++ b/src/main/java/com/dieselpoint/norm/sqlmakers/StandardPojoInfo.java
@@ -1,32 +1,19 @@
 package com.dieselpoint.norm.sqlmakers;
 
+import com.dieselpoint.norm.ColumnOrder;
+import com.dieselpoint.norm.DbException;
+import com.dieselpoint.norm.serialize.DbSerializer;
+
+import javax.persistence.*;
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.*;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.persistence.AttributeConverter;
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-
-import com.dieselpoint.norm.ColumnOrder;
-import com.dieselpoint.norm.DbException;
-import com.dieselpoint.norm.serialize.DbSerializer;
 
 /**
  * Provides means of reading and writing properties in a pojo.
@@ -176,7 +163,7 @@ public class StandardPojoInfo implements PojoInfo {
 
 	/**
 	 * Apply the annotations on the field or getter method to the property.
-	 * 
+	 *
 	 * @throws IllegalAccessException
 	 * @throws InstantiationException
 	 */
@@ -313,7 +300,6 @@ public class StandardPojoInfo implements PojoInfo {
 				throw new DbException(
 						"Could not set value into pojo. Field: " + prop.field.toString() + " value: " + value, e);
 			}
-			return;
 		}
 
 	}
@@ -324,7 +310,7 @@ public class StandardPojoInfo implements PojoInfo {
 	private <T extends Enum<T>> Object getEnumConst(Class<T> enumType, EnumType type, Object value) {
 		String str = value.toString();
 		if (type == EnumType.ORDINAL) {
-			Integer ordinalValue = (Integer) value;
+			int ordinalValue = (Integer) value;
 			if (ordinalValue < 0 || ordinalValue >= enumType.getEnumConstants().length) {
 				throw new DbException(
 						"Invalid ordinal number " + ordinalValue + " for enum class " + enumType.getCanonicalName());


### PR DESCRIPTION
According to the javadoc, you can use table() to specify the table to operate. But the fact is that when you insert, update or upsert rows, the table argument is ignored by StandardSqlMaker and MySqlMaker, making their behavior opposite to the javadoc.

This pull request is going to fix this, coming with some cleanup and dependency upgrades.