### PR TITLE
Support db.where().count(), since falling back to db.sql every time feels wrong

### DIFF
--- a/src/main/java/com/dieselpoint/norm/Query.java
+++ b/src/main/java/com/dieselpoint/norm/Query.java
@@ -109,6 +109,16 @@ public class Query {
 		}
 	}
 
+	public Long count() {
+		sql = sqlMaker.getSelectCountSql(this, null);
+		return first( Long.class );
+	}
+
+	public Long count(Class<?> clazz) {
+		sql = sqlMaker.getSelectCountSql(this, clazz);
+		return first( Long.class );
+	}
+
 	/**
 	 * Provides the results as a list of Map objects instead of a list of pojos.
 	 */

--- a/src/main/java/com/dieselpoint/norm/sqlmakers/SqlMaker.java
+++ b/src/main/java/com/dieselpoint/norm/sqlmakers/SqlMaker.java
@@ -21,6 +21,7 @@ public interface SqlMaker {
 	public Object[] getUpsertArgs(Query query, Object row);
 
 	public String getSelectSql(Query query, Class<?> rowClass);
+	public String getSelectCountSql(Query query, Class<?> tableClass);
 
 	public String getCreateTableSql(Class<?> clazz);
 

--- a/src/main/java/com/dieselpoint/norm/sqlmakers/StandardSqlMaker.java
+++ b/src/main/java/com/dieselpoint/norm/sqlmakers/StandardSqlMaker.java
@@ -183,6 +183,34 @@ public class StandardSqlMaker implements SqlMaker {
 	}
 
 	@Override
+	public String getSelectCountSql(Query query, Class<?> tableClass) {
+
+		// unlike insert and update, this needs to be done dynamically
+		// and can't be precalculated because of the where and order by
+
+		String table = query.getTable();
+		if (table == null) {
+			if (tableClass != null) {
+				StandardPojoInfo pojoInfo = getPojoInfo(tableClass);
+				table = pojoInfo.table;
+			}
+			else {
+				throw new DbException("You must specify a table name. Use either db.table(\"XXX\").where(...).count(...), or db.where(...).count(Pojoclass.class)" );
+			}
+		}
+		StringBuilder out = new StringBuilder();
+		out.append("select count(*) from ");
+		out.append(table);
+		String where = query.getWhere();
+		if (where != null) {
+			out.append(" where ");
+			out.append(where);
+		}
+		return out.toString();
+	}
+
+
+	@Override
 	public String getCreateTableSql(Class<?> clazz) {
 
 		StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
A minor (backward-compatible) addition to support:
 `db.table("...").where(...).count()`
or the more norm idiomatic:
  `db.where(...).count(Pojoclass.class)`

I find myself doing this all the time, and falling back to:
`db.sql("select count(*) from my_table where thing=wotsit").first(Long.class)`
seems gratuitous.