### PR TITLE
Added support for LocalDateTime as a data type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>3.5.7</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>2.3.232</version>

--- a/src/main/java/com/dieselpoint/norm/sqlmakers/StandardPojoInfo.java
+++ b/src/main/java/com/dieselpoint/norm/sqlmakers/StandardPojoInfo.java
@@ -10,6 +10,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -319,6 +321,9 @@ public class StandardPojoInfo implements PojoInfo {
 					if (prop.field.getType().equals(Long.TYPE) || prop.field.getType().equals(Long.class)) {
 						value = ((BigInteger) value).longValue();
 					}
+				}
+				if (value instanceof Timestamp && prop.dataType == LocalDateTime.class) {
+					value = ((Timestamp) value).toLocalDateTime();
 				}
 				prop.field.set(pojo, value);
 			} catch (IllegalArgumentException | IllegalAccessException e) {

--- a/src/test/java/com/dieselpoint/norm/TestLocalDateTime.java
+++ b/src/test/java/com/dieselpoint/norm/TestLocalDateTime.java
@@ -1,0 +1,70 @@
+package com.dieselpoint.norm;
+
+import com.dieselpoint.norm.sqlmakers.MySqlMaker;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TestLocalDateTime
+{
+	static String DB_DRIVER_CLASS_NAME = "org.mariadb.jdbc.Driver";
+	static String DB_SERVER_URL = "jdbc:mariadb://localhost:3306/test?allowPublicKeyRetrieval=true";
+	static String DB_USERNAME = "test_user";
+	static String DB_PASSWORD = "testUserPassword123!";
+
+	private static Database db;
+
+	@BeforeClass
+	public static void setUp() throws SQLException
+	{
+		db = new Database();
+		DriverManager.registerDriver(new org.mariadb.jdbc.Driver());
+		db.setDriverClassName(DB_DRIVER_CLASS_NAME);
+		db.setJdbcUrl(DB_SERVER_URL);
+		db.setUser(DB_USERNAME);
+		db.setPassword(DB_PASSWORD);
+		db.setSqlMaker(new MySqlMaker());
+		db.sql("TRUNCATE test.foo").execute();
+	}
+
+	@Test
+	public void testInsert() {
+		Foo foo = new Foo();
+		foo.startTime = LocalDateTime.of(1953, 1, 2, 3, 4, 5);
+		db.insert(foo);
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testSelect() {
+		List<Foo> results = db.results(Foo.class);
+		Assert.assertEquals(1, results.size());
+		Foo foo = results.get(0);
+		Assert.assertEquals(1953, foo.startTime.getYear());
+		Assert.assertEquals(1, foo.startTime.getMonthValue());
+		Assert.assertEquals(2, foo.startTime.getDayOfMonth());
+		Assert.assertEquals(3, foo.startTime.getHour());
+		Assert.assertEquals(4, foo.startTime.getMinute());
+		Assert.assertEquals(5, foo.startTime.getSecond());
+	}
+
+	@Table(schema = "test", name = "foo")
+	public static class Foo
+	{
+		@Id
+		@GeneratedValue
+		public long id;
+		@Column(name = "start_time")
+		public LocalDateTime startTime;
+	}
+
+}


### PR DESCRIPTION
I would prefer to be able to use the newer java.time options with the DATETIME column type. This adds support for LocalDateTime specifically.

It would be nice to use type hints instead on the [getObject](https://github.com/dieselpoint/norm/blob/master/src/main/java/com/dieselpoint/norm/Query.java#L228 ) call directly, but that requires more work